### PR TITLE
Add keyboard shortcuts for PDF zoom & rotation

### DIFF
--- a/pdf-review/components/PDFViewer.js
+++ b/pdf-review/components/PDFViewer.js
@@ -1,49 +1,74 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { Document, Page } from "react-pdf"
 
 const PDFViewer = ({ url }) => {
-  const [rotation, updateRotation] = useState(270)
-  const [pageCount, updatePageCount] = useState(0)
-  const [zoom, updateZoom] = useState(2.1)
+  const [rotation, setRotation] = useState(270)
+  const [pageCount, setPageCount] = useState(0)
+  const [zoom, setZoom] = useState(2.1)
   const pages = []
 
   for (var i = 1; i <= pageCount; i++) {
     pages.push(i)
   }
 
+  function handleKeyUp(e) {
+    const { key, shiftKey } = e
+
+    if (!shiftKey) return
+
+    if (key === "ArrowRight") {
+      rotateClockwise(e)
+    } else if (key === "ArrowLeft") {
+      rotateCounterClockwise(e)
+    } else if (key === "+") {
+      zoomIn(e)
+    } else if (key === "_") {
+      zoomOut(e)
+    }
+  }
+
   function handleLoadSuccess(e) {
     const { numPages } = e._pdfInfo
-    updatePageCount(numPages)
+    setPageCount(numPages)
   }
 
   function rotateCounterClockwise(e) {
     e.preventDefault()
-    if (rotation === 0) return updateRotation(270)
-    updateRotation(rotation - 90)
+    if (rotation === 0) return setRotation(270)
+    setRotation(rotation - 90)
   }
 
   function rotateClockwise(e) {
     e.preventDefault()
-    if (rotation === 270) return updateRotation(0)
-    updateRotation(rotation + 90)
+    if (rotation === 270) return setRotation(0)
+    setRotation(rotation + 90)
   }
 
   function zoomOut(e) {
     e.preventDefault()
-    updateZoom(zoom - 0.1)
+    setZoom(zoom - 0.1)
   }
+
   function zoomIn(e) {
     e.preventDefault()
-    updateZoom(zoom + .1)
+    setZoom(zoom + 0.1)
   }
+
+  useEffect(() => {
+    window.addEventListener("keyup", handleKeyUp, true)
+
+    return () => {
+      window.removeEventListener("keyup", handleKeyUp, true)
+    }
+  }, [handleKeyUp])
 
   return (
     <div className="pdf-viewer">
       <div className="pdf-viewer-buttons">
-        <button onClick={rotateCounterClockwise}>-90°</button>
-        <button onClick={rotateClockwise}>90°</button>
-        <button onClick={zoomOut}>-</button>
-        <button onClick={zoomIn}>+</button>
+        <button title="Rotate counter clockwise (hold shift and left arrow)" onClick={rotateCounterClockwise}>-90°</button>
+        <button title="Rotate clockwise (hold shift and right arrow)" onClick={rotateClockwise}>90°</button>
+        <button title="Zoom out (hold shift and minus)" onClick={zoomOut}>-</button>
+        <button title="Zoom in (hold shift and plus)" onClick={zoomIn}>+</button>
       </div>
       <div className="pdf-viewer-document">
         <Document file={url} height={600} onLoadSuccess={handleLoadSuccess}>


### PR DESCRIPTION
It'd be great if we hooked up the PDF document controls to some keyboard shortcuts so that if a person presses `Shift` and:

* the right arrow then the document should rotate clockwise
* the left arrow then the document should rotate counter clockwise
* the plus key then the document should zoom in
* the negative key then the document should zoom out

This isn't working for some reason, probably because I don't actually understand how to use hooks.